### PR TITLE
Allow subdirectory deployment

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -34,4 +34,6 @@ require ::File.expand_path('../config/environment',  __FILE__)
 #  Rails.backtrace_cleaner.remove_filters!
 #end
 
-run SparcRails::Application
+map ENV['RAILS_RELATIVE_URL_ROOT'] || "/" do
+  run SparcRails::Application
+end

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -52,5 +52,5 @@ SparcRails::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'sparc-demo.musc.edu' }
+  config.action_mailer.default_url_options = { :host => 'sparc-demo.musc.edu', :script_name => Rails.application.config.relative_url_root }
 end

--- a/config/environments/demo2.rb
+++ b/config/environments/demo2.rb
@@ -52,5 +52,5 @@ SparcRails::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'sparc-demo2.musc.edu' }
+  config.action_mailer.default_url_options = { :host => 'sparc-demo2.musc.edu', :script_name => Rails.application.config.relative_url_root }
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,7 +42,7 @@ SparcRails::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.default_url_options = { :host => 'localhost:3000', :script_name => Rails.application.config.relative_url_root }
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,12 +95,12 @@ SparcRails::Application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.delivery_method = :sendmail
-  config.action_mailer.default_url_options = { host: "sparc.musc.edu" }
+  config.action_mailer.default_url_options = { host: "sparc.musc.edu", :script_name => Rails.application.config.relative_url_root }
   config.after_initialize do
     # Need to do this after initialization so that obis_setup has run and our config is loaded
     if defined? ROOT_URL
       unless ROOT_URL.nil?
-        new_options = { host: ROOT_URL.sub(/^http(s)?\:\/\//, '') }
+        new_options = { host: ROOT_URL.sub(/^http(s)?\:\/\//, ''), :script_name => Rails.application.config.relative_url_root }
         config.action_mailer.default_url_options = new_options
 
         # By the time we run ActionMailer has already copied the options

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -92,5 +92,5 @@ SparcRails::Application.configure do
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 
-  config.action_mailer.default_url_options = { :host => 'sparc-s.obis.musc.edu' }
+  config.action_mailer.default_url_options = { :host => 'sparc-s.obis.musc.edu', :script_name => Rails.application.config.relative_url_root }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,7 +54,7 @@ SparcRails::Application.configure do
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :silence
 
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.default_url_options = { :host => 'localhost:3000', :script_name => Rails.application.config.relative_url_root }
 
   # Paperclip
   Paperclip::Attachment.default_options[:path] = "#{Rails.root}/spec/test_files/:class/:id_partition/:style.:extension"

--- a/config/environments/testing.rb
+++ b/config/environments/testing.rb
@@ -52,5 +52,5 @@ SparcRails::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'sparc-d.obis.musc.edu' }
+  config.action_mailer.default_url_options = { :host => 'sparc-d.obis.musc.edu', :script_name => Rails.application.config.relative_url_root }
 end

--- a/config/environments/testing_rails_4.rb
+++ b/config/environments/testing_rails_4.rb
@@ -53,5 +53,5 @@ SparcRails::Application.configure do
   # Expands the lines which load the assets
   config.assets.debug = true
 
-  config.action_mailer.default_url_options = { :host => 'sparc-d.obis.musc.edu' }
+  config.action_mailer.default_url_options = { :host => 'sparc-d.obis.musc.edu', :script_name => Rails.application.config.relative_url_root }
 end


### PR DESCRIPTION
Not all organizations deploy applications at the root of a domain and require it
to be hosted in a subdirectory. Based on the following links this is a supported
practice.

https://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root
https://gist.github.com/ebeigarts/5450422

This patch allows sites to deploy it either at the root or under a subdirectory.